### PR TITLE
Keeping keyboard current with most recent TMK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@
 TARGET = fs01_lufa
 
 # Directory common source files exist
-TOP_DIR = ../..
-LUFA_PATH = protocol/lufa/LUFA-130901
+TOP_DIR = ../../tmk_core
+TMK_DIR = $(TOP_DIR)
 
 # Directory keyboard dependent files exist
 TARGET_DIR = .

--- a/keymap_common.c
+++ b/keymap_common.c
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 /* translates key to keycode */
-uint8_t keymap_key_to_keycode(uint8_t layer, key_t key)
+uint8_t keymap_key_to_keycode(uint8_t layer, keypos_t key)
 {
     return pgm_read_byte(&keymaps[(layer)][(key.row)][(key.col)]);
 }


### PR DESCRIPTION
The following changes are necessary in order for this keyboard to work with the most recent version of the TMK firmware:
- the path to the tmk_core code has changed
- a TMK_DIR environment variable is now needed
- the LUFA firmware is able to detect it's path based on the TMK_DIR variable
- the key_t type no longer exists.
  